### PR TITLE
Improve explanation in rules.md

### DIFF
--- a/public/docs/development/rules.md
+++ b/public/docs/development/rules.md
@@ -26,7 +26,7 @@ Rather than offering a complex feature set, Harp has simple rules on how it work
          |   +- nav.jade          <-- a partial for navigation
          +- articles/             <-- pages in here will have "/articles/" in URL
              |- _data.json        <-- articles metadata goes here
-             +- hello-world.jade  <-- must have an index.html or index.jade file
+             +- hello-world.jade  <-- must have at least one *.html or *.jade file
     ```
 
 2. ## The root directory is public.


### PR DESCRIPTION
I came across a bit of confusion on the last line of explanation, in Documentation → The Rules → [Anatomy of a typical Harp application](http://harpjs.com/docs/development/rules):

```
+- hello-world.jade  <-- must have an index.html or index.jade file
```

This line shows a **custom-named** file (`hello-world.jade`) while explaining that there must be a **fixed-name** `index` file (of which none exist in the `articles/` dir of this example).

Maybe it's too early in the morning for me, but this is not self-explanatory to me – is it required to have a html or hade file that's _exactly_ named `index.ext` or not? Or is the actual requirement that there's _at least_ one jade or html file in here? The messages are mixed regarding what's really required.

As I understand, the `index.jade` file in the `public/` dir _has_ to be explicitly named `index`, right? If so, I think this possibly adds to the confusion regarding the above. (Again, this might be only me.)

Perhaps stating there must be `at least one *html or *jade file` might alleviate the risk for confusion?
