### PR TITLE
Fix typos in index.jade

### DIFF
--- a/public/index.jade
+++ b/public/index.jade
@@ -13,7 +13,7 @@
             img(src="/images/features/feature-preprocessors.png").image-feature
           .col-12.col-lg-5.col-offset-1
             h3 Automatic preprocessing
-            p Harp automatically preprocess code and serves it to the browser as HTML, CSS, JavaScript. Now you can focus on writing instead of wrangling.
+            p Harp automatically preprocesses code and serves it to the browser as HTML, CSS, and JavaScript. Now you can focus on writing instead of wrangling.
             a(href="/docs/quick-start") Get started
         .row
           .col-12.col-lg-6
@@ -37,7 +37,7 @@
       .feature
         .col-12.col-lg-4.col-offset-1
           h3 Preprocessors are built-in
-          p Harp already includes the preprocessors you love: <a href="/docs/development/markdown">Markdown</a>, <a href="/docs/development/jade">Jade</a>, <a href="/docs/development/ejs>EJS</a>, <a href="/docs/development/less">LESS</a>, <a href="/docs/development/stylus">Stylus</a>, <a href="/docs/development/sass">Sass</a> and <a href="/docs/development/coffeescript">CoffeeScript</a>, are all available without any configuration or setup necessary.
+          p Harp already includes the preprocessors you love: <a href="/docs/development/markdown">Markdown</a>, <a href="/docs/development/jade">Jade</a>, <a href="/docs/development/ejs">EJS</a>, <a href="/docs/development/less">LESS</a>, <a href="/docs/development/stylus">Stylus</a>, <a href="/docs/development/sass">Sass</a> and <a href="/docs/development/coffeescript">CoffeeScript</a>, are all available without any configuration or setup necessary.
         .col-12.col-lg-6
           .row
             a.col-lg-6(href="/docs/development/less"): img(alt="Write CSS with LESS" src="/images/icons/less-logo.svg")
@@ -113,11 +113,11 @@
           p Or, skip compiling all together, and publish from Dropbox with the <a href="http://harp.io/">Harp Platform</a>.
         .col-12.col-lg-6
           //- Harp Platform, Heroku, Nodejitsu, GitHub Pages, Cordova, Firefox OS
-          a.col-lg-12(href="http://harp.io"): img(title="Stylus" src="/images/icons/harp-platform-logo.svg")
+          a.col-lg-12(href="http://harp.io"): img(title="Harp" src="/images/icons/harp-platform-logo.svg")
           a.col-lg-6(href="/docs/deployment/github-pages"): img(title="GitHub" src="/images/icons/github-logo.svg")
           a.col-lg-6(href="/docs/deployment/heroku"): img(title="Heroku" src="/images/icons/heroku-logo.svg")
           //- a.col-lg-6(href="/docs/deployment/nodejitsu")
-          img.col-lg-6(title="Heroku" src="/images/icons/nodejitsu-logo.svg")
+          img.col-lg-6(title="Nodejitsu" src="/images/icons/nodejitsu-logo.svg")
           //- a.col-lg-6(href="/docs/deployment/cordova")
           img.col-lg-6(title="Cordova" src="/images/icons/cordova-logo.png")
           //- a.col-lg-6(href="/docs/deployment/firefox-os"): img(title="FireFox OS" src="/images/icons/firefox-os-logo.svg")


### PR DESCRIPTION
Fixes a couple of minor typos, including a broken link and erroneous image titles.
