### PR TITLE
Fixed typo - changed `index.jade` to `index.ejs`

### DIFF
--- a/public/docs/development/contents.md
+++ b/public/docs/development/contents.md
@@ -21,7 +21,7 @@ myproject/
 
 ### Using EJS
 
-Now, within `index.jade` you can iterate over the `_contents`, referencing each file.
+Now, within `index.ejs` you can iterate over the `_contents`, referencing each file.
 
 ```ejs
 <% for(var i in public.images._contents){ %>


### PR DESCRIPTION
Changed `index.jade` to `index.ejs` where the code sample was referring to `index.ejs` contents @ ### Using EJS