### PR TITLE
Update the Heroku deployment docs

### DIFF
--- a/public/docs/deployment/heroku.md
+++ b/public/docs/deployment/heroku.md
@@ -6,21 +6,17 @@ If you’re familiar with using git in the command line, you’ll have no troubl
 
 ## Create a Heroku account
 
-If you haven’t already, create a [Heroku account](https://api.heroku.com/signup/devcenter) and install their [toolbelt](https://toolbelt.heroku.com/). Then, using the Terminal, login with the username and password you chose:
+If you haven’t already, create a [Heroku account](https://signup.heroku.com/signup/dc) and install their [toolbelt](https://toolbelt.heroku.com/). Then, using the Terminal, login with the username and password you chose:
 
 ```sh
 heroku login
 ```
 
+## Create or use an existing application
+
 Now you’re ready to being modifying your Harp app to prepare it for Heroku. If you don’t have an existing app, or would like to try out deployment with the default app, you may [use `harp init` to initialize a new application](/docs/environment/init).
 
-## The Harp Buildpack
-
-The easiest way to deploy your application to Heroku is with [@zeke’s Harp buildpack](https://github.com/zeke/harp-buildpack).
-
-1. ## Create or use an existing application
-
-  If you need a new application, create a directory with an index file. You can do this with the terminal, too:
+Otherwise, create a directory with an index file. You can do this with the terminal, too:
 
   ```sh
   mkdir my-harp-app
@@ -28,50 +24,9 @@ The easiest way to deploy your application to Heroku is with [@zeke’s Harp bui
   echo "hello world" > index.html
   ```
 
-2. ## Initialize your app as a Git repo
+## Add `package.json` and `Procfile`
 
-  Next, you’ll initialize your Harp app as a Git repository (if it isn’t one already.) Then, add and commit the changes:
-
-  ```sh
-  git init
-  git add .
-  git commit -am "hello world"
-  ```
-
-3. ## Use the buildpack
-
-  Create a new application on Heroku, set to use the Harp buildpack.
-
-  ```
-  heroku create my-harp-app
-  heroku config:set BUILDPACK_URL=https://github.com/zeke/harp-buildpack.git
-  ```
-
-4. ## Deploy your application to Heroku
-
-  Push to Heroku and see your application online:
-
-  ```
-  git push heroku master
-  heroku open
-  ```
-
-5. ## Set the production environment
-
-To get the best performance, you’ll need to set Harp’s production properly. The Heroku buildpack can’t take care of this for you [yet](https://github.com/zeke/harp-buildpack/issues/8):
-
-
-```bash
-heroku config:set NODE_ENV="production"
-```
-
-## Deploy to Heroku manually
-
-If you’d like to deploy a Harp application to Heroku manually, use the following instructions instead.
-
-1. ## Add `package.json` and `server.js` 
-
-   There are two files you’ll need to add to the root of your Harp application (not inside the `public` directory). The first is `package.json`:
+  There are two files you’ll need to add to the root of your Harp application (not inside the `public` directory). The first is `package.json`:
 
   ```json
    {
@@ -80,43 +35,40 @@ If you’d like to deploy a Harp application to Heroku manually, use the followi
      "description": "A Harp App on Heroku",
      "dependencies": {
        "harp": "*"
-     },
-     "engines": {
-       "node": "0.10.x",
-       "npm": "1.2.x"
      }
    }
    ```
 
-   Then, use Node Package Manager to install the dependencies:
+  If you already have a `package.json`, the easiest way to add harp to the dependency list is by running:
 
-   ```
-   npm install
-   ```
+  ```sh
+  npm install harp --save
+  ```
 
-   Next, create `server.js`, which should contain the following:
+  Next, create `Procfile`, which should contain the following:
 
-   ```js
-   require('harp').server(__dirname, { port: process.env.PORT || 5000 })
-   ```
+  ```
+  web: harp server --port $PORT
+  ```
 
-2. ## Initialize your app as a Git repo
+## Initialize your app as a Git repo
 
-   Using the terminal, initialize your Harp app as a Git repository (if it isn’t one already.) Then, add and commit the changes:
+  Using the terminal, initialize your Harp app as a Git repository (if it isn’t one already). Then, add and commit the changes:
 
-   ```sh
-   git init
-   git add .
-   git commit -m "First Harp + Heroku commit"
-   ```
+  ```sh
+  git init
+  git add .
+  git commit -am "First Harp + Heroku commit"
+  ```
 
-3. ## Deploy to Heroku
+## Deploy to Heroku
 
-   You’re ready to deploy to Heroku. Create the Harp app as a Heroku app, and then use `git` to push the app to Heroku.
+   You’re ready to deploy to Heroku. Create the Harp app as a Heroku app, use `git` to push the app to Heroku, and then open the site in your browser:
 
    ```sh
    heroku create my-harp-app
    git push heroku master
+   heroku open
    ```
 
    In this example, the application will be named `my-harp-app`, and should be immediately available at `my-harp-app.herokuapp.com`.


### PR DESCRIPTION
zeke's harp buildpack has been deprecated, and in the meantime it's now become simpler to use the official Heroku nodejs buildpack directly.

If no Procfile is provided, Heroku runs `npm start` by default, meaning that in theory the creation of the Procfile could be skipped - and instead a "start" script entry added to `package.json`. However on Windows the `--port ${PORT:-9000}` parameter isn't expanded by `npm start`, so the "start" script would have to omit it.

As such, it's just easier to add a Procfile directly (which can specify the Heroku-specific $PORT variable) and leave it up to the user what they add for a "start" script in package.json. For people used to Heroku it's also more explicit what command the web process is running, if they see a Procfile in the repo.

Fixes #53.