### PR TITLE
Supply missing double quote.

### DIFF
--- a/public/recipes/custom-title-description.md
+++ b/public/recipes/custom-title-description.md
@@ -57,7 +57,7 @@ doctype
 html(lang="en")
   head
     title= title
-    meta(name="description" content="#{ description })
+    meta(name="description" content="#{ description }")
   body
     != yield
 ```


### PR DESCRIPTION
Missing double quote causes issues if you copy and paste the example, which I did. :)