### PR TITLE
Remove 'sudo' for npm install.

### DIFF
--- a/public/docs/quick-start.md
+++ b/public/docs/quick-start.md
@@ -13,7 +13,7 @@ This guide will help you install Harp. You’ll create and serve a simple projec
   Access the command prompt using the Terminal application. On OS X, it’s located in Applications → Utilities → Terminal. On Ubuntu, find it in Applications → Terminal. Then, run the following command:
 
   ```bash
-  sudo npm install -g harp
+  npm install -g harp
   ```
 
   ### On Windows


### PR DESCRIPTION
```sudo``` is [not good practice for npm, generally speaking](https://github.com/sass/node-sass/issues/1098) and actually resulted in installation errors for me. Running without ```sudo``` did worked great.