### PR TITLE
Change `index.ejs` to `index.jade`

### DIFF
--- a/public/docs/development/layout.md
+++ b/public/docs/development/layout.md
@@ -72,7 +72,7 @@ The final result:
 
 <h2 id="jade">Example using Jade Templating</h2>
 
-Harp allows you to apply a `.jade` file extension on your layout as well. Mixing and matching templates is also acceptable such as in the following case where we have a `_layout.jade` and `index.ejs`.
+Harp allows you to apply a `.jade` file extension on your layout as well. Mixing and matching templates is also acceptable such as in the following case where we have a `_layout.jade` and `index.jade`.
 
 Given a really simple app / project with this structure:
 


### PR DESCRIPTION
The Jade Templating example uses `_layout.jade` and `index.jade`, but it refers to `index.ejs`. This PR fixes that.